### PR TITLE
Fix pbd_env problem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,9 +7,9 @@ Description: An interface to parallel input output packages
 Version: 0.1-0
 License: Mozilla Public License 2.0
 Depends:
-    R (>= 3.0.0)
+    R (>= 3.0.0),
+    pbdMPI (>= 0.3.2)
 Imports: 
-    pbdMPI (>= 0.3.2),
     data.table (>= 1.9.4)
 Enhances: pbdNCDF4,
     pbdADIOS

--- a/R/comm.chunk.r
+++ b/R/comm.chunk.r
@@ -40,7 +40,7 @@
 #' comm.chunk(16, all.rank=TRUE, p=5)
 #' comm.chunk(16, type="equal", all.rank=TRUE, p=5)
 #' comm.chunk(16, type="equal", lo.side="right", all.rank=TRUE, p=5)
-#' comm.chunk(16, p=5, rank=2)
+#' comm.chunk(16, p=5, rank=0)
 #' 
 #' @export
 comm.chunk <- function(N, form="number", type="balance", lo.side="left",

--- a/man/comm.chunk.Rd
+++ b/man/comm.chunk.Rd
@@ -48,7 +48,7 @@ library(pbdIO)
 comm.chunk(16, all.rank=TRUE, p=5)
 comm.chunk(16, type="equal", all.rank=TRUE, p=5)
 comm.chunk(16, type="equal", lo.side="right", all.rank=TRUE, p=5)
-comm.chunk(16, p=5, rank=2)
+comm.chunk(16, p=5, rank=0)
 
 }
 


### PR DESCRIPTION
- Update pbdMPI first.
- .pbd_env is not exported!
- After exported, it does not help the problem here, but may affect sealing problem ... not sure yet ... I have no time to test further ...
- Need it in Depends instead of Imports (idk. ask R gods why)
- It is better to put a donrun within examples, otherwise usually crash because size always is 1.
- It does not make sense to me for R CMD check to run examples in Rd files.
- Use tests instead.